### PR TITLE
✨ lingui-js: definemessage to accept string and message descriptor

### DIFF
--- a/packages/macro/global.d.ts
+++ b/packages/macro/global.d.ts
@@ -173,11 +173,17 @@ declare module "@lingui/macro" {
    *    message: `Welcome, ${name}!`,
    * });
    * ```
+   * 
+   * or
+   * 
+   * ```
+   * const message = defineMessage("Welcome, home!");
+   * ```
    *
-   * @param descriptor The message descriptor
+   * @param descriptor The message descriptor or string
    */
   export function defineMessage(
-    descriptor: MessageDescriptor
+    descriptor: MessageDescriptor | string
   ): MessageDescriptor
 
   export type ChoiceProps = {

--- a/packages/macro/index.d.ts
+++ b/packages/macro/index.d.ts
@@ -162,10 +162,16 @@ export function select(value: string, choices: ChoiceOptions): string
  *    message: `Welcome, ${name}!`,
  * });
  * ```
+ * 
+ * or
+ * 
+ * ```
+ * const message = defineMessage("Welcome, home!");
+ * ```
  *
- * @param descriptor The message descriptor
+ * @param descriptor The message descriptor or string
  */
-export function defineMessage(descriptor: MessageDescriptor): MessageDescriptor
+export function defineMessage(descriptor: MessageDescriptor | string): MessageDescriptor
 
 export type TransProps = {
   id?: string

--- a/packages/macro/src/macroJs.ts
+++ b/packages/macro/src/macroJs.ts
@@ -165,8 +165,8 @@ export default class MacroJs {
   }
 
   /**
-   * macro `defineMessage` is called with MessageDescriptor. The only
-   * thing that happens is that any macros used in `message` property
+   * macro `defineMessage` is called with MessageDescriptor or string. The only
+   * thing that happens is that any macros used in `message` property or string
    * are replaced with formatted message.
    *
    * import { defineMessage, plural } from '@lingui/macro';
@@ -183,13 +183,30 @@ export default class MacroJs {
    *   comment: "Description",
    *   message: "{value, plural, one {book} other {books}}"
    * }
+   * 
+   * or 
+   * 
+   * const message = defineMessage("initiate success")
+   *
+   * ↓ ↓ ↓ ↓ ↓ ↓
+   *
+   * const message = {
+   *   id: "initiate success"
+   * }
    *
    */
   replaceDefineMessage = (path) => {
     // reset the expression counter
     this._expressionIndex = makeCounter()
 
-    const descriptor = this.processDescriptor(path.node.arguments[0])
+    const argValue = path.node.arguments[0]
+    const newNode = (this.types.isTemplateLiteral(argValue)  || this.types.isStringLiteral(argValue)) ?
+      this.types.objectExpression([
+      this.types.objectProperty(
+        this.types.identifier(MESSAGE),
+        argValue
+      )]) : argValue
+    const descriptor = this.processDescriptor(newNode)
     path.replaceWith(descriptor)
   }
 


### PR DESCRIPTION
@ Fix
1. converted string or literal param to object form  in replaceDefineMessage function using babel types functions.
2. added string type for defineMessage in type script and doc examples
   
@ Example

```
   import { defineMessage } from "@lingui/macro";
   const message = defineMessage({
       comment: "Greetings on the welcome page",
       message: `Welcome, ${name}!`,
    });
```
↓ ↓ ↓ ↓ ↓ ↓
   
```
const message = defineMessage("Welcome, home!");

```
